### PR TITLE
feat: set fr-FR preferred locale on Stripe customer creation

### DIFF
--- a/modules/payment/includes/stripe.php
+++ b/modules/payment/includes/stripe.php
@@ -189,6 +189,7 @@ class Stripe implements IPayment
 			$customerData = [
 				'email' => $data['member']['email'],
 				'name' => $data['member']['nom'] . " " . $data['member']['prenom'],
+				'preferred_locales' => ['fr-FR'],
 				'address' => [
 					'country' => 'FR',
 					'postal_code' => $data['member']['code_postal'],


### PR DESCRIPTION
## Summary
- Add `preferred_locales => ['fr-FR']` to the Stripe customer creation payload in `getOrCreateClient()` so newly created customers receive French-localized emails and invoices.
- Matches the `fr-FR` locale that was backfilled across all existing live customers, keeping old and new customers consistent.

## Changes
- `modules/payment/includes/stripe.php` — one line added to `$customerData`.

## Testing
- `php -l` passes (no syntax errors).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)